### PR TITLE
More complex workloads for `/light-task` and `/heavy-task`

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -39,12 +39,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["debug", "virtual:3c4f7f349789d7597b53f6806dcbf71445596dd97a6a139314a632324e544d12b73623cfb0621bb9d37d8830b5ffbaf5935d9d709ca211a5a162bb877a1524e9#npm:2.6.9"],
             ["dockerode", "https://github.com/kino-ma/dockerode.git#commit=d9fb220592a808511ec0bba5c2a975405ef44fce"],
             ["express", "npm:4.16.4"],
-            ["faas-app", "file:./faas-app/pkg#./faas-app/pkg::hash=82d701&locator=serverless-edge%40workspace%3A."],
+            ["faas-app", "file:./faas-app/pkg#./faas-app/pkg::hash=cfab04&locator=serverless-edge%40workspace%3A."],
             ["http-errors", "npm:1.6.3"],
             ["jest", "virtual:972573b93ea133a3fb1c4a26fd4a7839cf65bab68bc33fdccf375629ab808cd1dc33c319d0ed9e5e99a5a02a1ee59968f26935d2d37a5c8bf9a3ec34d54f4306#npm:27.4.7"],
             ["memory-streams", "npm:0.1.3"],
             ["morgan", "npm:1.9.1"],
             ["pug", "npm:2.0.0-beta11"],
+            ["readable-stream", "npm:3.6.0"],
             ["supertest", "npm:6.2.2"],
             ["vm2", "npm:3.9.5"]
           ],
@@ -2769,10 +2770,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["faas-app", [
-        ["file:./faas-app/pkg#./faas-app/pkg::hash=82d701&locator=serverless-edge%40workspace%3A.", {
-          "packageLocation": "./.yarn/cache/faas-app-file-cc5838746d-0a9896464b.zip/node_modules/faas-app/",
+        ["file:./faas-app/pkg#./faas-app/pkg::hash=cfab04&locator=serverless-edge%40workspace%3A.", {
+          "packageLocation": "./.yarn/cache/faas-app-file-4ae1a3ffc6-4e9db17d79.zip/node_modules/faas-app/",
           "packageDependencies": [
-            ["faas-app", "file:./faas-app/pkg#./faas-app/pkg::hash=82d701&locator=serverless-edge%40workspace%3A."]
+            ["faas-app", "file:./faas-app/pkg#./faas-app/pkg::hash=cfab04&locator=serverless-edge%40workspace%3A."]
           ],
           "linkType": "HARD",
         }]
@@ -5408,12 +5409,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["debug", "virtual:3c4f7f349789d7597b53f6806dcbf71445596dd97a6a139314a632324e544d12b73623cfb0621bb9d37d8830b5ffbaf5935d9d709ca211a5a162bb877a1524e9#npm:2.6.9"],
             ["dockerode", "https://github.com/kino-ma/dockerode.git#commit=d9fb220592a808511ec0bba5c2a975405ef44fce"],
             ["express", "npm:4.16.4"],
-            ["faas-app", "file:./faas-app/pkg#./faas-app/pkg::hash=82d701&locator=serverless-edge%40workspace%3A."],
+            ["faas-app", "file:./faas-app/pkg#./faas-app/pkg::hash=cfab04&locator=serverless-edge%40workspace%3A."],
             ["http-errors", "npm:1.6.3"],
             ["jest", "virtual:972573b93ea133a3fb1c4a26fd4a7839cf65bab68bc33fdccf375629ab808cd1dc33c319d0ed9e5e99a5a02a1ee59968f26935d2d37a5c8bf9a3ec34d54f4306#npm:27.4.7"],
             ["memory-streams", "npm:0.1.3"],
             ["morgan", "npm:1.9.1"],
             ["pug", "npm:2.0.0-beta11"],
+            ["readable-stream", "npm:3.6.0"],
             ["supertest", "npm:6.2.2"],
             ["vm2", "npm:3.9.5"]
           ],

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL := /bin/bash
 WASM_BIND := faas-app/pkg/faas_app.js
+NATIVE_BUILD := faas-app/target/release/faas_bin
 DOCKER_RUST_NAME := faas-app-rust
 DOCKER_BIN_NAME := faas-bin
 UNAME := $(shell uname)
@@ -37,10 +38,12 @@ install: package.json
 rust-container:
 	$(DOCKER_RUST_START)
 
-bin-runner: bin
-	docker build -t $(DOCKER_BIN_NAME) .
+bin-runner: $(NATIVE_BUILD)
+	docker build -t $(DOCKER_BIN_NAME) --no-cache .
 
-bin:
+bin: $(NATIVE_BUILD)
+
+$(NATIVE_BUILD):
 	$(CARGO) build --release
 
 wasm: $(WASM_BIND)

--- a/faas-app/Cargo.lock
+++ b/faas-app/Cargo.lock
@@ -18,8 +18,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "faas-app"
 version = "0.1.0"
 dependencies = [
+ "serde",
+ "serde_json",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "lazy_static"
@@ -52,6 +60,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "serde"
+version = "1.0.135"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cf9235533494ea2ddcdb794665461814781c53f19d87b76e571a1c35acbad2b"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.135"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dcde03d87d4c973c04be249e7d8f0b35db1c848c487bd43032808e59dd8328d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/faas-app/Cargo.toml
+++ b/faas-app/Cargo.toml
@@ -20,6 +20,8 @@ path = "src/bin.rs"
 
 [dependencies]
 wasm-bindgen = "0.2.78"
+serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-Oz", "--enable-mutable-globals"]

--- a/faas-app/src/bin.rs
+++ b/faas-app/src/bin.rs
@@ -1,38 +1,33 @@
-use std::env;
-use std::io::stdin;
+use std::io;
+
+use serde_json::{json, Value};
 
 use faas_lib as lib;
+use lib::Input;
 
 fn main() {
-    let input = stdin();
+    let stdin = io::stdin();
+    let mut buf = String::new();
+    stdin.read_line(&mut buf).unwrap();
 
-    let output: String = match env::args().nth(1).unwrap().as_str() {
+    let input: Input = serde_json::from_str(&buf).expect("invalid input");
+
+    let output: Value = match input.task.as_str() {
         "light" => {
-            let mut buf = String::new();
-            input.read_line(&mut buf).expect("failed to read input");
-            let arg = buf
-                .trim()
-                .parse::<isize>()
-                .expect("Invalid input (it must be a number)");
-            let output = lib::light_task(arg);
-            output.to_string()
+            let input = input.input.as_i64().expect("invalid number") as isize;
+            let output = lib::light_task(input);
+            json!(output)
         }
 
         "heavy" => {
-            let mut buf = String::new();
-            input.read_line(&mut buf).expect("failed to read input");
-            let arg = buf
-                .trim()
-                .parse::<isize>()
-                .expect("Invalid input (it must be a number)");
-            let output = lib::heavy_task(arg);
-            output.to_string()
+            let input = input.input.as_i64().expect("invalid number") as isize;
+            let output = lib::heavy_task(input);
+            json!(output)
         }
 
         "hello" => {
-            let mut buf = String::new();
-            input.read_line(&mut buf).expect("failed to read input");
-            lib::hello(&buf)
+            let input = input.input.to_string();
+            json!(lib::hello(&input))
         }
 
         _ => {
@@ -40,5 +35,5 @@ fn main() {
         }
     };
 
-    print!("{}", output);
+    print!(r#"{{"output":{}"#, output);
 }

--- a/faas-app/src/lib.rs
+++ b/faas-app/src/lib.rs
@@ -1,5 +1,50 @@
+mod nbody;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
+
+#[derive(Serialize, Deserialize)]
+pub struct Input {
+    pub input: Value,
+    pub task: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Output {
+    output: Value,
+}
+
+pub fn main(args: Value) -> Result<Value, serde_json::Error> {
+    let input: Input = serde_json::from_value(args)?;
+
+    let output: Value = match input.task.as_str() {
+        "light" => {
+            let input = input.input.as_i64().expect("invalid number") as isize;
+            let output = light_task(input);
+            json!(output)
+        }
+
+        "heavy" => {
+            let input = input.input.as_i64().expect("invalid number") as isize;
+            let output = heavy_task(input);
+            json!(output)
+        }
+
+        "hello" => {
+            let input = input.input.to_string();
+            json!(hello(&input))
+        }
+
+        _ => {
+            panic!("unexpected input")
+        }
+    };
+
+    return Ok(output);
+}
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub fn hello(name: &str) -> String {
@@ -7,17 +52,23 @@ pub fn hello(name: &str) -> String {
 }
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-pub fn heavy_task(input: isize) -> isize {
-    let mut sum = 0;
-    for _ in 1..=input {
-        sum += input;
-    }
-    sum
+pub fn heavy_task(input: isize) -> Box<[f64]> {
+    let (a, b) = nbody::run(input as usize);
+    Box::new([a, b])
 }
 
+/// Caluclates the Nth fibonacci number
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub fn light_task(input: isize) -> isize {
-    input + input
+    let n = input as usize;
+    let mut fibs = vec![0isize; n + 1];
+    fibs[1] = 1;
+
+    for i in 2..=n {
+        fibs[i] = fibs[i - 2] + fibs[i - 1];
+    }
+
+    return fibs[n];
 }
 
 #[cfg(test)]
@@ -30,5 +81,12 @@ mod tests {
         let actual = hello("rust-test");
 
         assert_eq!(expect, actual);
+    }
+
+    #[test]
+    fn hundredth_fib() {
+        let fib50 = light_task(50);
+
+        assert_eq!(fib50, 12586269025)
     }
 }

--- a/faas-app/src/nbody.rs
+++ b/faas-app/src/nbody.rs
@@ -1,0 +1,275 @@
+/*
+ * Copyright © 2004-2008 Brent Fulgham, 2005-2022 Isaac Gouy
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name "The Computer Language Benchmarks Game" nor the name "The Benchmarks Game" nor the name "The Computer Language Shootout Benchmarks" nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Copied from Benchmarks Game, n-body Rust #6 program (Jan 24, 2021)
+// with some modifications:
+//   - Added above license.
+//   - Deleted main() function.
+//   - Applied formatter
+//
+// See: https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/nbody-rust-6.html
+
+// The Computer Language Benchmarks Game
+// http://benchmarksgame.alioth.debian.org/
+//
+// contributed by the packed_simd developers
+// contributed by Andre Bogus
+
+use std::f64::consts::PI;
+use std::ops::*;
+
+const SOLAR_MASS: f64 = 4.0 * PI * PI;
+const DAYS_PER_YEAR: f64 = 365.24;
+
+#[derive(Copy, Clone)]
+pub struct F64x2(f64, f64);
+
+#[derive(Copy, Clone)]
+pub struct F64x4(f64, f64, f64, f64);
+
+impl F64x2 {
+    pub fn splat(x: f64) -> F64x2 {
+        F64x2(x, x)
+    }
+    pub fn new(a: f64, b: f64) -> F64x2 {
+        F64x2(a, b)
+    }
+    pub fn sqrt(self) -> F64x2 {
+        F64x2(self.0.sqrt(), self.1.sqrt())
+    }
+    pub fn write_to_slice_unaligned(self, slice: &mut [f64]) {
+        slice[0] = self.0;
+        slice[1] = self.1;
+    }
+}
+
+impl F64x4 {
+    pub fn splat(x: f64) -> F64x4 {
+        F64x4(x, x, x, x)
+    }
+    pub fn new(a: f64, b: f64, c: f64, d: f64) -> F64x4 {
+        F64x4(a, b, c, d)
+    }
+    pub fn sum(self) -> f64 {
+        (self.0 + self.1) + (self.2 + self.3)
+    }
+}
+
+impl Mul for F64x2 {
+    type Output = Self;
+    fn mul(self, rhs: Self) -> Self {
+        F64x2(self.0 * rhs.0, self.1 * rhs.1)
+    }
+}
+impl Div for F64x2 {
+    type Output = Self;
+    fn div(self, rhs: Self) -> Self {
+        F64x2(self.0 / rhs.0, self.1 / rhs.1)
+    }
+}
+
+impl Add for F64x4 {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self {
+        F64x4(
+            self.0 + rhs.0,
+            self.1 + rhs.1,
+            self.2 + rhs.2,
+            self.3 + rhs.3,
+        )
+    }
+}
+impl Sub for F64x4 {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self {
+        F64x4(
+            self.0 - rhs.0,
+            self.1 - rhs.1,
+            self.2 - rhs.2,
+            self.3 - rhs.3,
+        )
+    }
+}
+impl Mul for F64x4 {
+    type Output = Self;
+    fn mul(self, rhs: Self) -> Self {
+        F64x4(
+            self.0 * rhs.0,
+            self.1 * rhs.1,
+            self.2 * rhs.2,
+            self.3 * rhs.3,
+        )
+    }
+}
+
+impl Mul<f64> for F64x4 {
+    type Output = F64x4;
+    fn mul(self, rhs: f64) -> F64x4 {
+        self * F64x4::splat(rhs)
+    }
+}
+
+pub struct Body {
+    pub x: F64x4,
+    pub v: F64x4,
+    pub mass: f64,
+}
+
+const N_BODIES: usize = 5;
+fn bodies() -> [Body; N_BODIES] {
+    [
+        // sun:
+        Body {
+            x: F64x4::new(0., 0., 0., 0.),
+            v: F64x4::new(0., 0., 0., 0.),
+            mass: SOLAR_MASS,
+        },
+        // jupiter:
+        Body {
+            x: F64x4::new(
+                4.84143144246472090e+00,
+                -1.16032004402742839e+00,
+                -1.03622044471123109e-01,
+                0.,
+            ),
+            v: F64x4::new(
+                1.66007664274403694e-03 * DAYS_PER_YEAR,
+                7.69901118419740425e-03 * DAYS_PER_YEAR,
+                -6.90460016972063023e-05 * DAYS_PER_YEAR,
+                0.,
+            ),
+            mass: 9.54791938424326609e-04 * SOLAR_MASS,
+        },
+        // saturn:
+        Body {
+            x: F64x4::new(
+                8.34336671824457987e+00,
+                4.12479856412430479e+00,
+                -4.03523417114321381e-01,
+                0.,
+            ),
+            v: F64x4::new(
+                -2.76742510726862411e-03 * DAYS_PER_YEAR,
+                4.99852801234917238e-03 * DAYS_PER_YEAR,
+                2.30417297573763929e-05 * DAYS_PER_YEAR,
+                0.,
+            ),
+            mass: 2.85885980666130812e-04 * SOLAR_MASS,
+        },
+        // uranus:
+        Body {
+            x: F64x4::new(
+                1.28943695621391310e+01,
+                -1.51111514016986312e+01,
+                -2.23307578892655734e-01,
+                0.,
+            ),
+            v: F64x4::new(
+                2.96460137564761618e-03 * DAYS_PER_YEAR,
+                2.37847173959480950e-03 * DAYS_PER_YEAR,
+                -2.96589568540237556e-05 * DAYS_PER_YEAR,
+                0.,
+            ),
+            mass: 4.36624404335156298e-05 * SOLAR_MASS,
+        },
+        // neptune:
+        Body {
+            x: F64x4::new(
+                1.53796971148509165e+01,
+                -2.59193146099879641e+01,
+                1.79258772950371181e-01,
+                0.,
+            ),
+            v: F64x4::new(
+                2.68067772490389322e-03 * DAYS_PER_YEAR,
+                1.62824170038242295e-03 * DAYS_PER_YEAR,
+                -9.51592254519715870e-05 * DAYS_PER_YEAR,
+                0.,
+            ),
+            mass: 5.15138902046611451e-05 * SOLAR_MASS,
+        },
+    ]
+}
+
+pub fn offset_momentum(bodies: &mut [Body; N_BODIES]) {
+    let (sun, rest) = bodies.split_at_mut(1);
+    let sun = &mut sun[0];
+    for body in rest {
+        let m_ratio = body.mass / SOLAR_MASS;
+        sun.v = sun.v - body.v * m_ratio;
+    }
+}
+
+pub fn energy(bodies: &[Body; N_BODIES]) -> f64 {
+    let mut e = 0.;
+    for i in 0..N_BODIES {
+        let bi = &bodies[i];
+        e += bi.mass * (bi.v * bi.v).sum() * 0.5;
+        for bj in &bodies[i + 1..] {
+            let dx = bi.x - bj.x;
+            e -= bi.mass * bj.mass / (dx * dx).sum().sqrt()
+        }
+    }
+    e
+}
+
+pub fn advance(bodies: &mut [Body; N_BODIES], dt: f64) {
+    const N: usize = N_BODIES * (N_BODIES - 1) / 2;
+
+    // compute distance between bodies:
+    let mut r = [F64x4::splat(0.); N];
+    {
+        let mut i = 0;
+        for j in 0..N_BODIES {
+            for k in j + 1..N_BODIES {
+                r[i] = bodies[j].x - bodies[k].x;
+                i += 1;
+            }
+        }
+    }
+
+    let mut mag = [0.0; N];
+    let mut i = 0;
+    while i < N {
+        let d2s = F64x2::new((r[i] * r[i]).sum(), (r[i + 1] * r[i + 1]).sum());
+        let dmags = F64x2::splat(dt) / (d2s * d2s.sqrt());
+        dmags.write_to_slice_unaligned(&mut mag[i..]);
+        i += 2;
+    }
+
+    i = 0;
+    for j in 0..N_BODIES {
+        for k in j + 1..N_BODIES {
+            let f = r[i] * mag[i];
+            bodies[j].v = bodies[j].v - f * bodies[k].mass;
+            bodies[k].v = bodies[k].v + f * bodies[j].mass;
+            i += 1
+        }
+    }
+    for body in bodies {
+        body.x = body.x + body.v * dt;
+    }
+}
+
+pub fn run(n: usize) -> (f64, f64) {
+    let mut bodies = bodies();
+    offset_momentum(&mut bodies);
+    let energy_before = energy(&bodies);
+    for _ in 0..n {
+        advance(&mut bodies, 0.01);
+    }
+    let energy_after = energy(&bodies);
+    (energy_before, energy_after)
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "memory-streams": "^0.1.3",
     "morgan": "~1.9.1",
     "pug": "2.0.0-beta11",
+    "readable-stream": "^3.6.0",
     "vm2": "^3.9.5"
   },
   "devDependencies": {

--- a/server/invoker.js
+++ b/server/invoker.js
@@ -23,10 +23,7 @@ const heavy = (input) => {
     container.manualStart();
     return callVirtualized(heavy_task, input);
   } else {
-    if (input.indexOf('\n') < 0) {
-      input += "\n";
-    }
-    return container.startAndExec(input)
+    return container.startAndExec({ input: parseInt(input), task: "heavy" })
   }
 };
 
@@ -36,10 +33,7 @@ const light = (input) => {
     container.manualStart();
     return callVirtualized(light_task, input);
   } else {
-    if (input.indexOf('\n') < 0) {
-      input += "\n";
-    }
-    return container.startAndExec(input)
+    return container.startAndExec({ input: parseInt(input), task: "light" })
   }
 };
 
@@ -65,11 +59,7 @@ const date = async (_input) => {
 
 const invokeHello = async (input) => {
   const container = helloContainer;
-  if (input.indexOf('\n') < 0) {
-    input += "\n";
-  }
-  const output = await container.startAndExec(input);
-  return output;
+  return container.startAndExec({ input, task: "hello" });
 }
 
 const invokeWasmHello = async (name) => {

--- a/utils/container.js
+++ b/utils/container.js
@@ -119,10 +119,17 @@ class CachingContainer extends Container {
     }
   }
 
-  async startAndExec(input = "") {
+  async startAndExec(input) {
     if (!this.running) {
       await this.manualStart();
     }
+
+    if (typeof input === "object") {
+      input = JSON.stringify(input) + "\n";
+    } else if (typeof input === "undefined") {
+      input = ""
+    }
+    console.log({ input })
 
     const stdin = new streams.ReadableStream(input);
 
@@ -136,9 +143,9 @@ const containers = {
 
 const dateRunner = new CachingContainer(["date", "+%s"]);
 
-const helloContainer = new CachingContainer(["/root/faas_bin", "hello"]);
-const lightContainer = new CachingContainer(["/root/faas_bin", "light"]);
-const heavyContainer = new CachingContainer(["/root/faas_bin", "heavy"]);
+const helloContainer = new CachingContainer(["/root/faas_bin"]);
+const lightContainer = new CachingContainer(["/root/faas_bin"]);
+const heavyContainer = new CachingContainer(["/root/faas_bin"]);
 
 const callContainer = () => {
   return docker.run("ubuntu", ["date", "+%s"], process.stdout, { AutoRemove: true });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2066,8 +2066,8 @@ __metadata:
 
 "faas-app@file:./faas-app/pkg::locator=serverless-edge%40workspace%3A.":
   version: 0.1.0
-  resolution: "faas-app@file:./faas-app/pkg#./faas-app/pkg::hash=82d701&locator=serverless-edge%40workspace%3A."
-  checksum: 0a9896464ba8108d4b34f9b9f2201c500652c0109561b7d775cb65959464fa78a014ddf1b6729911f76dc3eef29caca004b3011e5b12452da074257329bc84f4
+  resolution: "faas-app@file:./faas-app/pkg#./faas-app/pkg::hash=cfab04&locator=serverless-edge%40workspace%3A."
+  checksum: 4e9db17d790e3bbb41904851fc3bf778587c5c68b4e7ca20c771d8313bcad4a2f3da2c107af519f58f7abe77caaa1261f7b1b603a184b10e11d94b7eb1f030fa
   languageName: node
   linkType: hard
 
@@ -4401,6 +4401,7 @@ __metadata:
     memory-streams: ^0.1.3
     morgan: ~1.9.1
     pug: 2.0.0-beta11
+    readable-stream: ^3.6.0
     supertest: ^6.1.6
     vm2: ^3.9.5
   languageName: unknown


### PR DESCRIPTION
I chose `n-body` and `fibonacci` from the [BenchmarksGame](https://benchmarksgame-team.pages.debian.net/benchmarksgame/index.html) by Debian and [Benchmarking WebAssembly Runtimes](https://medium.com/wasmer/benchmarking-webassembly-runtimes-18497ce0d76e) by Wasmer team.

For a better measurement, the following arguments are suggested:
- `/light-task`: `1` - `92`
    - The algorithm is only O(N). Even if you give a very large number (e.g., 100,000,000), the response time doesn't extend so long.
    - But, you *can* give such number although the number overflows (from `93`) or fails to allocate memory ;).
- `/heavy-task`: `1,000,000` - `100,000,000`
   - This is also an O(N) computation, but it takes more time for a single loop.