### PR TITLE
Container execution time estimation returns `Infinity`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "cookie-parser": "~1.4.4",
-    "debug": "~2.6.9",
+    "debug": "^4.3.3",
     "dockerode": "https://github.com/kino-ma/dockerode#exec-buf",
     "eslint": "^8.8.0",
     "express": "~4.16.1",

--- a/server/invoker/container.js
+++ b/server/invoker/container.js
@@ -1,4 +1,5 @@
 const { spawn, Thread, Worker } = require("threads");
+const debug = require("debug")("container-invoker");
 
 const { ReusableInvoker } = require("./invoker");
 
@@ -34,6 +35,7 @@ class ContainerInvoker extends ReusableInvoker {
 
   async estimateNext() {
     const coldStarts = await this.worker.getColdStarts();
+    debug("cold starts: ", coldStarts);
     const warmStartElapsed = this.elapsedTimeHistory.reduce((arr, elem, i) => {
       if (i === coldStarts[0]) {
         coldStarts.shift();
@@ -42,6 +44,8 @@ class ContainerInvoker extends ReusableInvoker {
       }
       return arr;
     }, []);
+
+    debug("warm start elapsed: ", warmStartElapsed);
 
     const warmStartAvg = this.averageElapsedTime({
       customHist: warmStartElapsed,

--- a/server/invoker/workers/container.js
+++ b/server/invoker/workers/container.js
@@ -1,4 +1,5 @@
 const { expose } = require("threads/worker");
+const debug = require("debug")("container-worker");
 
 const { CachingContainer } = require("../../../utils/container");
 
@@ -14,7 +15,7 @@ expose({
   async run(task, input) {
     const isIntTask = intTasks.includes(task);
 
-    coldStarts.push(!container.isRunning);
+    coldStarts.push(!container.running);
 
     const res = await container.startAndExec({
       input: isIntTask ? parseInt(input) : input,
@@ -28,7 +29,10 @@ expose({
   },
 
   coldStartTime() {
-    return container.elapsedTime.start ?? Infinity;
+    debug({ elapsedTimes: container.elapsedTime });
+    return container.elapsedTime.start === null
+      ? container.elapsedTime.start
+      : Infinity;
   },
 
   getColdStarts() {

--- a/utils/container.js
+++ b/utils/container.js
@@ -1,5 +1,6 @@
 const Docker = require("dockerode");
 const streams = require("./stream");
+const debug = require("debug")("container-utils");
 
 const wait = require("./wait");
 const { measure } = require("./perf");
@@ -55,6 +56,7 @@ class Container {
     );
 
     this.elapsedTime.start = elapsed;
+    debug("elapsed time set:", this.elapsedTime);
 
     return stream;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1982,7 +1982,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:2.6.9, debug@npm:~2.6.9":
+"debug@npm:2.6.9":
   version: 2.6.9
   resolution: "debug@npm:2.6.9"
   dependencies:
@@ -5228,7 +5228,7 @@ __metadata:
   resolution: "serverless-edge@workspace:."
   dependencies:
     cookie-parser: ~1.4.4
-    debug: ~2.6.9
+    debug: ^4.3.3
     dockerode: "https://github.com/kino-ma/dockerode#exec-buf"
     eslint: ^8.8.0
     express: ~4.16.1


### PR DESCRIPTION
`ContainerInvoker` was always returning `Infinity`. That was caused by a reference to the undefined field in `Container`, `isRunning` (i.e., `.running` is correct). Referrer was converting it to boolean by `!` operator, so `undefined` became `true`. I fix it in this PR.